### PR TITLE
fix: Remove shopid duplicate params and request

### DIFF
--- a/src/modules/item/request/get/GetAttributeRequest.ts
+++ b/src/modules/item/request/get/GetAttributeRequest.ts
@@ -15,8 +15,4 @@ export default interface GetAttributeRequest {
    * Is cross-border or not. Should be provided if no "shopid".
    */
   is_cb?: Boolean, 
-  /**
-   * Shopee's unique identifier for a shop. Should be provided if no "country" and "is_cb".
-   */
-  shopid: Number
 }


### PR DESCRIPTION
```
getAttributes(request: GetAttributeRequest) : Promise<GetAttributeResponse> {
    let full_url = this.client.defaults.baseURL + 'item/attributes/get';
    let params: any = {
      partner_id: Number(this.config.partner_id),
      shopid: Number(this.config.shop_id),
      timestamp: Math.round(Date.now() / 1000),
      ...request
    }
    let hmac = hmac256(this.config.partner_key || '', full_url + '|' + JSON.stringify(params))
    return this.client.post('item/attributes/get' ,params, {
      headers: {
        Authorization: hmac
      }
    }).then(handleReject);
  }
```

shopid in params and shopid in getAttributeRequest is duplicate